### PR TITLE
Handle the fact that branch may not be protected

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           context: ./1
           push: true
-          tags: etsinfra/drone-bump-version:latest,etsinfra/drone-bump-version:1.0.1
+          tags: etsinfra/drone-bump-version:latest,etsinfra/drone-bump-version:1.0.2

--- a/1/Dockerfile
+++ b/1/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6-buster
+FROM python:3.9.7-buster
 
 COPY bump_version.py /plugin_script/bump_version.py
 COPY requirements.txt /plugin_script/requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2021-09-16
+### Fixed
+- Version bump is now properly performed even if there is no branch protection.
+
 ## [1.0.1] - 2021-08-05
 ### Fixed
 - Version bump is now properly performed even if previous versions do not have the same number of digits.
@@ -43,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/ets-infra/drone-bump-version/compare/1.0.1...master
+[Unreleased]: https://github.com/ets-infra/drone-bump-version/compare/1.0.2...master
+[1.0.2]: https://github.com/ets-infra/drone-bump-version/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/ets-infra/drone-bump-version/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/ets-infra/drone-bump-version/compare/0.2.1...1.0.0
 [0.2.1]: https://github.com/ets-infra/drone-bump-version/compare/0.2.0...0.2.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Supported tags and respective Dockerfile links
 
-- [`1.0.1`, `latest`](https://github.com/ets-infra/drone-bump-version/blob/master/1/Dockerfile)
+- [`1.0.2`, `latest`](https://github.com/ets-infra/drone-bump-version/blob/master/1/Dockerfile)
 
 # Quick reference (cont.)
 
@@ -26,7 +26,7 @@ The following steps are executed by this plugin:
 | changelog_path | Path to the changelog. Default to `CHANGELOG.md` in current folder. |
 | version_file_path | Path to the python file containing the version. If not provided, no file will be updated. |
 | skip_commit_author | If provided and the value matches the one from [the commit author user name](https://docs.drone.io/pipeline/environment/reference/drone-commit-author/), this plugin will not do anything. |
-| github_token | Token (repo permission) used to commit and update repository permissions temporarily. Default to [the drone GIT password](https://docs.drone.io/server/reference/drone-git-password/) (if available). Related user needs to have admin role in repository. |
+| github_token | Token (repo permission) used to commit (and update repository permissions temporarily if needed). Default to [the drone GIT password](https://docs.drone.io/server/reference/drone-git-password/) (if available). Related user needs to have admin role in repository. |
 | user_name | Name of the GIT commit user. Default to [the drone GIT user name](https://docs.drone.io/pipeline/environment/reference/drone-commit-author-name/). |
 | user_email | email of the GIT commit user. Default to [the drone GIT user email](https://docs.drone.io/pipeline/environment/reference/drone-commit-author-email/). |
 


### PR DESCRIPTION
### Fixed
- Version bump is now properly performed even if there is no branch protection.
